### PR TITLE
Fix logic error with spider-bud

### DIFF
--- a/indiv_jokers/spider_bud.lua
+++ b/indiv_jokers/spider_bud.lua
@@ -25,6 +25,7 @@ joker.calculate = function(self, card, context)
     end
 
     if context.end_of_round and not context.blueprint and context.main_eval then
+        card.ability.extra.first = true
         if G.GAME.blind.boss then 
             G.hand:change_size(-card.ability.extra.cards)
             card.ability.extra.cards = 0 
@@ -32,7 +33,6 @@ joker.calculate = function(self, card, context)
                 message = localize('k_reset')
             }
         end
-        card.ability.extra.first = true
     end
 end
 


### PR DESCRIPTION
Boss blinds were causing it to return before resetting `card.ability.extra.first`; do things in the other order to prevent that